### PR TITLE
Catch errors during distance reading instead of exiting out of program

### DIFF
--- a/python/lidar_lite.py
+++ b/python/lidar_lite.py
@@ -35,8 +35,13 @@ class Lidar_Lite():
     return (res[0] << 8 | res[1])
 
   def getDistance(self):
-    self.writeAndWait(self.distWriteReg, self.distWriteVal)
-    dist = self.readDistAndWait(self.distReadReg1)
+    try:
+        self.writeAndWait(self.distWriteReg, self.distWriteVal)
+        dist = self.readDistAndWait(self.distReadReg1)
+    except (IOError, OSError) as err:
+        print(err)
+        return -1
+        
     return dist
 
   def getVelocity(self):


### PR DESCRIPTION
While using the library there would be at times when my program would exit while it was taking measurements. I am only using one i2c device, so nothing should be interfering with it. I found it more convenient to get a -1 as a marker that it was a bad measurement.